### PR TITLE
GRPC module version loading

### DIFF
--- a/lib/grpc.ex
+++ b/lib/grpc.ex
@@ -1,8 +1,10 @@
 defmodule GRPC do
+  @version GRPC.Mixfile.project[:version]
+
   @doc """
   Returns version of this project.
   """
-  def version, do: GRPC.Mixfile.project[:version]
+  def version, do: @version
 
   @doc """
   Returns user agent used by HTTP/2.


### PR DESCRIPTION
Mix can not be used in escript or release.