### PR TITLE
fix __call_rpc function for compile warning

### DIFF
--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -45,8 +45,8 @@ defmodule GRPC.Server do
         def __call_rpc__(unquote(path), stream) do
           GRPC.Server.call(unquote(service_mod), stream, unquote(Macro.escape(rpc)), String.to_atom(unquote(func_name)))
         end
-        def __call_rpc(_, stream), do: {:error, stream, "Error"}
       end
+      def __call_rpc__(_, stream), do: {:error, stream, "Error"}
     end
   end
 


### PR DESCRIPTION
fix issue : https://github.com/tony612/grpc-elixir/issues/31