### PR TITLE
Add support for streamed messages split in multiple frames

### DIFF
--- a/lib/grpc/message.ex
+++ b/lib/grpc/message.ex
@@ -58,4 +58,15 @@ defmodule GRPC.Message do
     <<_flag::bytes-size(1), _length::bytes-size(4), message::binary>> = data
     message
   end
+
+  def complete?(data) do
+    <<_flag::bytes-size(1), length::unsigned-integer-size(32), message::binary>> = data
+    length == byte_size(message)
+  end
+
+  def message_length(data) do
+    <<_flag::bytes-size(1), length::unsigned-integer-size(32), _message::binary>> = data
+    length
+  end
+
 end

--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -158,18 +158,41 @@ defmodule GRPC.Stub do
   end
 
   defp response_stream(%{unmarshal: unmarshal} = stream, opts) do
-    Stream.unfold([], fn acc ->
+    Stream.unfold(%{ complete: [], buffer: :empty, message_length: -1 }, fn acc ->
       case Channel.recv(stream, opts) do
         {:data, data} ->
-          reply = data
-          |> GRPC.Message.from_data
-          |> unmarshal.()
-          {reply, [acc] ++ reply}
+          if GRPC.Message.complete?(data) do
+            reply = data |> GRPC.Message.from_data() |> unmarshal.()
+            {reply, Map.update!(acc, :complete, &([&1] ++ reply))}
+          else
+            case acc do
+              %{ buffer: :empty } ->
+                {
+                  :skip,
+                  Map.merge(acc, %{
+                    buffer: data, message_length: GRPC.Message.message_length(data)
+                  })
+                }
+              %{ buffer: buffer, message_length: ml } when byte_size(buffer) + byte_size(data) >  ml ->
+                final_buffer = buffer <> data
+                reply = final_buffer
+                        |> GRPC.Message.from_data()
+                        |> unmarshal.()
+                {
+                  reply,
+                  Map.update!(acc, :complete, &([&1] ++ reply))
+                  |> Map.merge( %{ buffer: :empty, message_length: -1 })
+                }
+              %{ buffer: buffer } ->
+                next_buffer = buffer <> data
+                {:skip, Map.put(acc, :buffer, next_buffer) }
+            end
+          end
         {:end_stream, _resp} ->
           nil
         other ->
           other
       end
-    end)
+    end) |> Stream.reject(&match?(:skip, &1))
   end
 end


### PR DESCRIPTION
Hi,

As I mentioned in tony612/protobuf-elixir#11 I'm working on a Google Cloud Bigtable client and I'm running into problems working with googles developer emulator.

It turns out that the server might split the protobuf payload into multiple data frames that are less than the size of the payload even though the window size can contain the full payload. This results in an exception in [stub.ex L166](https://github.com/tony612/grpc-elixir/blob/87066828170f535330615f15dfe800b74380efdb/lib/grpc/stub.ex#L166) when the non-complete payload is unmarshalled. The exception is similar to the to the problem mentioned in #27 that was fixed in `parse_unary_response`.

This PR fixes this problem for streamed responses by buffering incomplete data frames until they are complete and can be treated as complete grpc messages.

One question:

The unfold accumulator keep a list of all the received data frames but doesn't use it for anything, what's the reason for this?