### PR TITLE
Expose all ssl options in GRPC.Credential

### DIFF
--- a/examples/route_guide/lib/app.ex
+++ b/examples/route_guide/lib/app.ex
@@ -18,7 +18,7 @@ defmodule Routeguide.App do
 
   defp start_args do
     if System.get_env("TLS") do
-      cred = GRPC.Credential.server_tls(@cert_path, @key_path)
+      cred = GRPC.Credential.new(ssl: [certfile: @cert_path, keyfile: @key_path])
       IO.inspect cred
       {Routeguide.RouteGuide.Server, 10000, cred: cred}
     else

--- a/examples/route_guide/priv/client.exs
+++ b/examples/route_guide/priv/client.exs
@@ -1,7 +1,7 @@
 opts =
   if System.get_env("TLS") do
     ca_path = Path.expand("./tls/ca.pem", :code.priv_dir(:route_guide))
-    cred = GRPC.Credential.client_tls(ca_path)
+    cred = GRPC.Credential.new(ssl: [cacertfile: ca_path])
     [cred: cred]
   else
     []

--- a/lib/grpc/adapter/chatterbox/client.ex
+++ b/lib/grpc/adapter/chatterbox/client.ex
@@ -15,8 +15,7 @@ defmodule GRPC.Adapter.Chatterbox.Client do
 
   def connect(%{host: host, port: port}, payload = %{cred: cred}) do
     pname = :"grpc_chatter_client_ssl_#{host}:#{port}"
-    ssl_opts = [cacertfile: cred.tls.ca_path]
-    init_args = {:client, :ssl, String.to_charlist(host), port, ssl_opts, :chatterbox.settings(:client)}
+    init_args = {:client, :ssl, String.to_charlist(host), port, cred.ssl, :chatterbox.settings(:client)}
     do_connect(pname, init_args, payload)
   end
 

--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -122,8 +122,7 @@ defmodule GRPC.Adapter.Cowboy do
     list = [port: port, num_acceptors: @num_acceptors]
     list = if opts[:ip], do: [{:ip, opts[:ip]}|list], else: list
     if opts[:cred] do
-      tls_cred = opts[:cred].tls
-      [{:certfile, tls_cred.cert_path}, {:keyfile, tls_cred.key_path}|list]
+      opts[:cred].ssl ++ list
     else
       list
     end

--- a/lib/grpc/credential.ex
+++ b/lib/grpc/credential.ex
@@ -3,22 +3,13 @@ defmodule GRPC.Credential do
   Stores credentials for authentication.
   """
 
-  @type t :: %__MODULE__{tls: GRPC.Credential.ClientTLS.t | GRPC.Credential.ServerTLS.t}
-  defstruct [:tls]
+  @type t :: %__MODULE__{ssl: [:ssl.ssl_option]}
+  defstruct [:ssl]
 
   @doc """
-  Creates server TLS credential.
+  Creates credential.
   """
-  def server_tls(cert_path, key_path) do
-    tls = %GRPC.Credential.ServerTLS{cert_path: cert_path, key_path: key_path}
-    %__MODULE__{tls: tls}
-  end
-
-  @doc """
-  Creates client TLS credential.
-  """
-  def client_tls(ca_path) do
-    tls = %GRPC.Credential.ClientTLS{ca_path: ca_path}
-    %__MODULE__{tls: tls}
+  def new(opts) do
+    %__MODULE__{ssl: Keyword.get(opts, :ssl, [])}
   end
 end

--- a/test/grpc/channel_test.exs
+++ b/test/grpc/channel_test.exs
@@ -10,7 +10,7 @@ defmodule GRPC.ChannelTest do
   end
 
   test "connect/2 works for ssl" do
-    cred = %{tls: %{}}
+    cred = %{ssl: []}
     {:ok, channel} = GRPC.Stub.connect("10.1.0.0:50051", adapter: ClientAdapter, cred: cred)
     assert %Channel{host: "10.1.0.0", port: 50051, scheme: "https",
             payload: %{pname: :grpc_test_client_ssl_dapter, cred: ^cred}} = channel

--- a/test/grpc/integration/connection_test.exs
+++ b/test/grpc/integration/connection_test.exs
@@ -27,11 +27,11 @@ defmodule GRPC.Integration.ConnectionTest do
 
   test "authentication works" do
     server = FeatureServer
-    cred = GRPC.Credential.server_tls(@cert_path, @key_path)
+    cred = GRPC.Credential.new(ssl: [certfile: @cert_path, keyfile: @key_path])
     {:ok, _, port} = GRPC.Server.start(server, 0, cred: cred)
     try do
       point = Routeguide.Point.new(latitude: 409_146_138, longitude: -746_188_906)
-      client_cred = GRPC.Credential.client_tls(@ca_path)
+      client_cred = GRPC.Credential.new(ssl: [cacertfile: @ca_path])
       {:ok, channel} = GRPC.Stub.connect("localhost:#{port}", cred: client_cred)
       assert channel |> Routeguide.RouteGuide.Stub.get_feature(point)
     after


### PR DESCRIPTION
GRPC.Credential requires paths to certs and keys. It's not always convenient to store certs and keys as files. For example, one common way of including a CA bundle is [certifi](https://github.com/certifi/erlang-certifi). Using certifi the certs are returned as a binary.

Instead of creating options structs specific to grpc-elixir maybe it would be better to pass an `ssl_option` list (from [erlang ssl](erlang.org/doc/man/ssl.html)) through. Both the client and the server would accept the same options so it would mean you could do away with the client/server specific credentials. This would also be a little bit closer to the way credentials are implemented in some of the [official GRPC libraries](https://grpc.io/docs/guides/auth.html#using-client-side-ssltls).
