### PR TITLE
Define @default_timeout in usecs

### DIFF
--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -41,8 +41,9 @@ defmodule GRPC.Stub do
   @insecure_scheme "http"
   @secure_scheme "https"
   @canceled_error GRPC.RPCError.exception(GRPC.Status.cancelled(), "The operation was cancelled")
+
   # 5 seconds
-  @default_timeout 5000
+  @default_timeout 5_000_000
 
   defmacro __using__(opts) do
     quote bind_quoted: [service_mod: opts[:service]] do


### PR DESCRIPTION
I think I've figured out part of the problem in this issue https://github.com/tony612/grpc-elixir/issues/48.

The default timeout was set to `5000`, but when it is encoded it is sent in microseconds.

- https://github.com/tony612/grpc-elixir/blob/master/lib/grpc/transport/http2.ex#L81
- https://github.com/tony612/grpc-elixir/blob/master/lib/grpc/transport/utils.ex#L13

I've changed the constant to `5_000_000` to reflect this in the stub.
