### PR TITLE
server: add new process in cowboy_loop to handle state

### DIFF
--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -65,12 +65,12 @@ defmodule GRPC.Adapter.Cowboy do
     :cowboy.stop_listener(servers_name(servers))
   end
 
-  @spec read_body(GRPC.Client.Stream.t()) :: {:ok, binary, GRPC.Client.Stream.t()}
+  @spec read_body(GRPC.Adapter.Cowboy.Handler.state()) :: {:ok, binary}
   def read_body(%{pid: pid}) do
     Handler.read_full_body(pid)
   end
 
-  @spec reading_stream(GRPC.Client.Stream.t(), ([binary] -> [struct])) :: Enumerable.t()
+  @spec reading_stream(GRPC.Adapter.Cowboy.Handler.state(), ([binary] -> [struct])) :: Enumerable.t()
   def reading_stream(%{pid: pid}, func) do
     Stream.unfold(%{pid: pid, frames: [], buffer: ""}, fn acc -> read_stream(acc, func) end)
   end
@@ -105,7 +105,7 @@ defmodule GRPC.Adapter.Cowboy do
     end
   end
 
-  @spec send_reply(GRPC.Client.Stream.t(), binary) :: any
+  @spec send_reply(GRPC.Adapter.Cowboy.Handler.state(), binary) :: any
   def send_reply(%{pid: pid}, data) do
     Handler.stream_body(pid, data, :nofin)
   end

--- a/lib/grpc/adapter/cowboy/handler.ex
+++ b/lib/grpc/adapter/cowboy/handler.ex
@@ -10,9 +10,9 @@ defmodule GRPC.Adapter.Cowboy.Handler do
 
   @adapter GRPC.Adapter.Cowboy
   @default_trailers HTTP2.server_trailers()
-  @typep state :: %{pid: pid}
+  @type state :: %{pid: pid}
 
-  @spec init(map, {GRPC.Server.servers_map(), keyword}) :: {:ok, map, state}
+  @spec init(map, {GRPC.Server.servers_map(), keyword}) :: {:cowboy_loop, map, state}
   def init(req, {servers, _opts}) do
     path = :cowboy_req.path(req)
     server = Map.get(servers, GRPC.Server.service_name(path))

--- a/lib/grpc/adapter/cowboy/handler.ex
+++ b/lib/grpc/adapter/cowboy/handler.ex
@@ -6,35 +6,170 @@ defmodule GRPC.Adapter.Cowboy.Handler do
 
   alias GRPC.Transport.HTTP2
   alias GRPC.RPCError
+  require Logger
 
   @adapter GRPC.Adapter.Cowboy
   @default_trailers HTTP2.server_trailers()
-  @typep state :: {GRPC.Server.servers_map(), keyword}
+  @typep state :: %{pid: pid}
 
-  @spec init(map, state) :: {:ok, map, state}
-  def init(req, {servers, _opts} = state) do
+  @spec init(map, {GRPC.Server.servers_map(), keyword}) :: {:ok, map, state}
+  def init(req, {servers, _opts}) do
     path = :cowboy_req.path(req)
     server = Map.get(servers, GRPC.Server.service_name(path))
-    stream = %GRPC.Server.Stream{server: server, adapter: @adapter, payload: req}
-    stream = @adapter.set_headers(stream, HTTP2.server_headers())
+    stream = %GRPC.Server.Stream{server: server, adapter: @adapter, payload: %{pid: self()}}
+	  pid = spawn_link(__MODULE__, :call_rpc, [server, path, stream])
 
+    req = :cowboy_req.set_resp_headers(HTTP2.server_headers(), req)
+    Process.flag(:trap_exit, true)
+    {:cowboy_loop, req, %{pid: pid}}
+  end
+
+  # APIs begin
+  def read_full_body(pid) do
+    sync_call(pid, :read_full_body)
+  end
+
+  def read_body(pid) do
+    sync_call(pid, :read_body)
+  end
+
+  def stream_body(pid, data, is_fin) do
+    send(pid, {:stream_body, self(), data, is_fin})
+  end
+
+  def stream_reply(pid, status, headers) do
+    send(pid, {:stream_reply, self(), status, headers})
+  end
+
+  def set_resp_headers(pid, headers) do
+    send(pid, {:set_resp_headers, self(), headers})
+  end
+
+  def set_resp_trailers(pid, trailers) do
+    send(pid, {:set_resp_trailers, self(), trailers})
+  end
+
+  def stream_trailers(pid, trailers) do
+    send(pid, {:stream_trailers, self(), trailers})
+  end
+
+  def get_headers(pid) do
+    sync_call(pid, :get_headers)
+  end
+
+  defp sync_call(pid, key) do
+    send(pid, {key, self()})
+    receive do
+      msg -> msg
+    end
+  end
+  # APIs end
+
+  def info({:read_full_body, pid}, req, state = %{pid: pid}) do
+    {s, body, req} = read_full_body(req, "")
+    send(pid, {s, body})
+    {:ok, req, state}
+  end
+  def info({:read_body, pid}, req, state = %{pid: pid}) do
+    {s, body, req} = :cowboy_req.read_body(req)
+    send(pid, {s, body})
+    {:ok, req, state}
+  end
+  def info({:stream_body, pid, data, is_fin}, req, state = %{pid: pid}) do
+    req = check_sent_resp(req)
+    :cowboy_req.stream_body(data, is_fin, req)
+    {:ok, req, state}
+  end
+  def info({:stream_reply, pid, status, headers}, req, state = %{pid: pid}) do
+    req = :cowboy_req.stream_reply(status, headers, req)
+    {:ok, req, state}
+  end
+  def info({:set_resp_headers, pid, headers}, req, state = %{pid: pid}) do
+    req = :cowboy_req.set_resp_headers(headers, req)
+    {:ok, req, state}
+  end
+  def info({:set_resp_trailers, pid, trailers}, req, state = %{pid: pid}) do
+    {:ok, req, Map.put(state, :resp_trailers, trailers)}
+  end
+  def info({:stream_trailers, pid, trailers}, req, state = %{pid: pid}) do
+    metadata = Map.get(state, :resp_trailers, %{})
+    metadata = GRPC.Transport.HTTP2.encode_metadata(metadata)
+    send_stream_trailers(req, Map.merge(metadata, trailers))
+    {:ok, req, state}
+  end
+  def info({:get_headers, pid}, req, state = %{pid: pid}) do
+    headers = :cowboy_req.headers(req)
+    send(pid, headers)
+    {:ok, req, state}
+  end
+
+  def info({:EXIT, pid, :normal}, req, state = %{pid: pid}) do
+    {:stop, req, state}
+  end
+  def info({:EXIT, pid, {%RPCError{} = error, _stacktrace}}, req, state = %{pid: pid}) do
+    trailers = HTTP2.server_trailers(error.status, error.message)
+    send_stream_trailers(req, trailers)
+    {:stop, req, state}
+  end
+  def info({:EXIT, pid, {:handle_error, _kind}}, req, state = %{pid: pid}) do
+    error = %RPCError{status: GRPC.Status.unknown(), message: "Internal Server Error"}
+    trailers = HTTP2.server_trailers(error.status, error.message)
+    send_stream_trailers(req, trailers)
+    {:stop, req, state}
+  end
+  def info({:EXIT, pid, {reason, stacktrace}}, req, state = %{pid: pid}) do
+    Logger.error(Exception.format(:error, reason, stacktrace))
+    error = %RPCError{status: GRPC.Status.unknown(), message: "Internal Server Error"}
+    trailers = HTTP2.server_trailers(error.status, error.message)
+    send_stream_trailers(req, trailers)
+    {:stop, req, state}
+  end
+
+  def call_rpc(server, path, stream) do
+    try do
+      do_call_rpc(server, path, stream)
+    rescue
+      e in RPCError ->
+        exit({e, ""})
+    catch
+      kind, e ->
+        Logger.error(Exception.format(kind, e))
+        exit({:handle_error, kind})
+    end
+  end
+
+  defp do_call_rpc(server, path, stream) do
     case server.__call_rpc__(path, stream) do
       {:ok, stream, response} ->
-        stream =
-          stream
-          |> GRPC.Server.send_reply(response)
-          |> GRPC.Server.send_trailers(@default_trailers)
+        stream
+        |> GRPC.Server.send_reply(response)
+        |> GRPC.Server.send_trailers(@default_trailers)
 
-        {:ok, stream.payload, state}
+        {:ok, stream}
 
       {:ok, stream} ->
-        stream = GRPC.Server.send_trailers(stream, @default_trailers)
-        {:ok, stream.payload, state}
+        GRPC.Server.send_trailers(stream, @default_trailers)
+        {:ok, stream}
+    end
+  end
 
-      {:error, stream, %RPCError{} = error} ->
-        trailers = HTTP2.server_trailers(error.status, error.message)
-        stream = GRPC.Server.send_trailers(stream, trailers)
-        {:ok, stream.payload, state}
+  defp read_full_body(req, body) do
+    case :cowboy_req.read_body(req) do
+      {:ok, data, req} -> {:ok, body <> data, req}
+      {:more, data, req} -> read_full_body(req, body <> data)
+    end
+  end
+
+  defp send_stream_trailers(req, trailers) do
+    req = check_sent_resp(req)
+    :cowboy_req.stream_trailers(trailers, req)
+  end
+
+  defp check_sent_resp(req) do
+    if req[:has_sent_resp] == nil do
+      :cowboy_req.stream_reply(200, req)
+    else
+      req
     end
   end
 end

--- a/lib/grpc/server/stream.ex
+++ b/lib/grpc/server/stream.ex
@@ -15,7 +15,7 @@ defmodule GRPC.Server.Stream do
     * `:payload` - the payload needed by the adapter
   """
 
-  defstruct [:server, :marshal, :unmarshal, :payload, :adapter, :resp_trailers]
+  defstruct [:server, :marshal, :unmarshal, :payload, :adapter]
 
   @typep marshal :: (struct -> binary)
   @typep unmarshal :: (binary -> struct)
@@ -24,7 +24,6 @@ defmodule GRPC.Server.Stream do
           marshal: marshal,
           unmarshal: unmarshal,
           payload: any,
-          adapter: atom,
-          resp_trailers: map
+          adapter: atom
         }
 end

--- a/lib/grpc/stream.ex
+++ b/lib/grpc/stream.ex
@@ -11,8 +11,7 @@ defmodule GRPC.Stream do
   """
   @spec get_headers(GRPC.Server.Stream.t()) :: map
   def get_headers(%GRPC.Server.Stream{adapter: adapter} = stream) do
-    stream
-    |> adapter.get_headers()
-    |> GRPC.Transport.HTTP2.decode_headers()
+    headers = adapter.get_headers(stream.payload)
+    GRPC.Transport.HTTP2.decode_headers(headers)
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "cowboy": {:hex, :cowboy, "2.2.2", "6cde634da1da8b1d17dd2b20f5f6f91ab8ac7fa1b5106d13dad63c905ab76004", [:rebar3], [{:cowlib, "~> 2.1.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.4.0", [hex: :ranch, optional: false]}]},
+  "cowboy": {:hex, :cowboy, "2.2.2", "6cde634da1da8b1d17dd2b20f5f6f91ab8ac7fa1b5106d13dad63c905ab76004", [:rebar3], [{:cowlib, "~> 2.1.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.4.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.1.0", "f73658b93dd043af40400c3e4fd997068ebd0c617f8c8f4cd003a1a78ebf94f5", [:rebar3], []},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},

--- a/test/support/test_adapter.exs
+++ b/test/support/test_adapter.exs
@@ -15,10 +15,6 @@ defmodule GRPC.Test.ServerAdapter do
     {stream, data}
   end
 
-  def flow_control(_, size) do
-    {:ok, size}
-  end
-
   def send_headers(stream, _headers) do
     stream
   end


### PR DESCRIPTION
I changed cowboy handler to a `:cowboy_loop` handler and spawn a process for user's rpc. In this way, we can:
1. Store state in the handler process so that we can manipulate `req` without passing it around.
2. We can add timeout to the rpc call, which will be easier than before.