### PR TITLE
Support domain sockets

### DIFF
--- a/interop/mix.exs
+++ b/interop/mix.exs
@@ -22,8 +22,7 @@ defmodule Interop.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:grpc, path: ".."},
-      {:gun, ">= 1.0.0-pre.5"}
+      {:grpc, path: ".."}
     ]
   end
 end

--- a/interop/mix.lock
+++ b/interop/mix.lock
@@ -1,7 +1,7 @@
 %{
   "cowboy": {:hex, :cowboy, "2.2.2", "6cde634da1da8b1d17dd2b20f5f6f91ab8ac7fa1b5106d13dad63c905ab76004", [:rebar3], [{:cowlib, "~> 2.1.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.4.0", [hex: :ranch, optional: false]}]},
-  "cowlib": {:hex, :cowlib, "2.1.0", "f73658b93dd043af40400c3e4fd997068ebd0c617f8c8f4cd003a1a78ebf94f5", [:rebar3], []},
-  "gun": {:hex, :gun, "1.0.0-pre.5", "69a11e259d5bf7fd9b1a74e1aa98e7979c2ae3ebbda27fe1b1c9cb4481f23ba3", [:rebar3], [{:cowlib, "~> 2.1", [repo: "hexpm", hex: :cowlib, optional: false]}, {:ranch, "~> 1.4", [repo: "hexpm", hex: :ranch, optional: false]}], "hexpm"},
+  "cowlib": {:git, "https://github.com/ninenines/cowlib.git", "804d5262a3369623683213b14d6b936066fc7aab", [tag: "2.4.0"]},
+  "gun": {:git, "https://github.com/ninenines/gun.git", "e49f8af96da160b0417d21d5550fedd216acc263", [tag: "1.0.0-rc.1"]},
   "protobuf": {:hex, :protobuf, "0.5.3", "7216b9814830a92384c4a99ca1ce35884614517c1cdf0c75ea74ea9bb9fabaeb", [:mix], []},
-  "ranch": {:hex, :ranch, "1.4.0", "10272f95da79340fa7e8774ba7930b901713d272905d0012b06ca6d994f8826b", [:rebar3], []},
+  "ranch": {:hex, :ranch, "1.4.0", "10272f95da79340fa7e8774ba7930b901713d272905d0012b06ca6d994f8826b", [:rebar3], [], "hexpm"},
 }

--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -182,8 +182,17 @@ defmodule GRPC.Adapter.Cowboy do
 
   defp running_info(scheme, servers, ref) do
     {addr, port} = :ranch.get_addr(ref)
-    addr_str = :inet.ntoa(addr)
-    "Running #{servers_name(servers)} with Cowboy using #{scheme}://#{addr_str}:#{port}"
+
+    addr_str =
+      case addr do
+        :local ->
+          port
+
+        addr ->
+          "#{:inet.ntoa(addr)}:#{port}"
+      end
+
+    "Running #{servers_name(servers)} with Cowboy using #{scheme}://#{addr_str}"
   end
 
   defp servers_name(servers) do

--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -142,6 +142,7 @@ defmodule GRPC.Server do
   # ## Examples
   #
   #     iex> {:ok, _, port} = GRPC.Server.start(Greeter.Server, 50051)
+  #     iex> {:ok, _, port} = GRPC.Server.start(Greeter.Server, 0, ip: {:local, "path/to/unix.sock"})
   #
   # ## Options
   #

--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -88,6 +88,9 @@ defmodule GRPC.Stub do
       iex> GRPC.Stub.connect("localhost:50051")
       {:ok, channel}
 
+      iex> GRPC.Stub.connect("/paht/to/unix.sock")
+      {:ok, channel}
+
   ## Options
 
     * `:cred` - a `GRPC.Credential` used to indicate it's a secure connection.
@@ -96,7 +99,12 @@ defmodule GRPC.Stub do
   """
   @spec connect(String.t(), Keyword.t()) :: {:ok, GRPC.Channel.t()} | {:error, any}
   def connect(addr, opts \\ []) when is_binary(addr) and is_list(opts) do
-    [host, port] = String.split(addr, ":")
+    {host, port} =
+      case String.split(addr, ":") do
+        [host, port] -> {host, port}
+        [socket_path] -> {{:local, socket_path}, 0}
+      end
+
     connect(host, port, opts)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule GRPC.Mixfile do
     [
       {:protobuf, "~> 0.5"},
       {:cowboy, "~> 2.2"},
-      {:gun, ">= 1.0.0-pre.5"},
+      {:gun, github: "ninenines/gun", tag: "1.0.0-rc.1"},
+      {:cowlib, github: "ninenines/cowlib", tag: "2.4.0", override: true},
       {:ex_doc, "~> 0.14", only: :dev},
       {:inch_ex, ">= 0.0.0", only: :docs},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,10 +1,10 @@
 %{
   "cowboy": {:hex, :cowboy, "2.2.2", "6cde634da1da8b1d17dd2b20f5f6f91ab8ac7fa1b5106d13dad63c905ab76004", [:rebar3], [{:cowlib, "~> 2.1.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.4.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
-  "cowlib": {:hex, :cowlib, "2.1.0", "f73658b93dd043af40400c3e4fd997068ebd0c617f8c8f4cd003a1a78ebf94f5", [:rebar3], []},
+  "cowlib": {:git, "https://github.com/ninenines/cowlib.git", "804d5262a3369623683213b14d6b936066fc7aab", [tag: "2.4.0"]},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "gun": {:hex, :gun, "1.0.0-pre.5", "69a11e259d5bf7fd9b1a74e1aa98e7979c2ae3ebbda27fe1b1c9cb4481f23ba3", [:rebar3], [{:cowlib, "~> 2.1", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.4", [hex: :ranch, optional: false]}]},
+  "gun": {:git, "https://github.com/ninenines/gun.git", "e49f8af96da160b0417d21d5550fedd216acc263", [tag: "1.0.0-rc.1"]},
   "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
   "protobuf": {:hex, :protobuf, "0.5.2", "c1338db827614cbe03a479ac9ef22bd8f3d0ff8a6bb44db5f63037688cd7806c", [:mix], []},

--- a/test/grpc/integration/connection_test.exs
+++ b/test/grpc/integration/connection_test.exs
@@ -25,6 +25,19 @@ defmodule GRPC.Integration.ConnectionTest do
     :ok = GRPC.Server.stop(server)
   end
 
+  test "connecting with a domain socket works" do
+    socket_path = "/tmp/grpc.sock"
+    server = FeatureServer
+    File.rm(socket_path)
+
+    {:ok, _, port} = GRPC.Server.start(server, 0, ip: {:local, socket_path})
+    {:ok, channel} = GRPC.Stub.connect(socket_path, adapter_opts: %{retry_timeout: 10})
+
+    point = Routeguide.Point.new(latitude: 409_146_138, longitude: -746_188_906)
+    assert {:ok, _} = channel |> Routeguide.RouteGuide.Stub.get_feature(point)
+    :ok = GRPC.Server.stop(server)
+  end
+
   test "authentication works" do
     server = FeatureServer
 


### PR DESCRIPTION
* Allow starting server listening on a domain socket
* Allow stub client to connect to domain sockets

I had to update the deps to use the latest [gun 1.0.0-rc.1](https://github.com/ninenines/gun/tree/1.0.0-rc.1), since it's not on hex yet it uses the git ref. I can update the PR when it's available on hex.