### PR TITLE
Passing JWT token in authorization header

### DIFF
--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -454,6 +454,10 @@ defmodule GRPC.Stub do
     parse_req_opts(t, Map.put(acc, :return_headers, return_headers))
   end
 
+  defp parse_req_opts([{:token, token} | t], acc) do
+    parse_req_opts(t, Map.put(acc, :token, token))
+  end
+
   defp parse_req_opts([{key, _} | _], _) do
     raise ArgumentError, "option #{inspect(key)} is not supported"
   end

--- a/lib/grpc/transport/http2.ex
+++ b/lib/grpc/transport/http2.ex
@@ -38,9 +38,9 @@ defmodule GRPC.Transport.HTTP2 do
     |> append_encoding(opts[:grpc_encoding])
     |> append_timeout(opts[:timeout])
     |> append_custom_metadata(opts[:metadata])
+    |> append_authorization(opts[:token])
 
     # TODO: grpc-accept-encoding, grpc-message-type
-    # TODO: Authorization
   end
 
   def extract_metadata(headers) do
@@ -88,6 +88,12 @@ defmodule GRPC.Transport.HTTP2 do
   end
 
   defp append_custom_metadata(headers, _), do: headers
+
+  defp append_authorization(headers, token) when is_binary(token) do
+    headers ++ [{"authorization", "Bearer #{token}"}]
+  end
+
+  defp append_authorization(headers, _), do: headers
 
   defp encode_metadata_pair({key, val}) when not is_binary(key) do
     encode_metadata_pair({to_string(key), val})


### PR DESCRIPTION
This pull request implements ability to specify a JWT access token per invocation of any client stub function. Example usage is provided in https://github.com/tony612/grpc-elixir/issues/71.

If I did anything wrong, please let me know.