### PR TITLE
Support Ranch 1.6 map-style transport opts

### DIFF
--- a/interop/mix.lock
+++ b/interop/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "8d634d0ff4ea1ca744a8a789aa5edf6682e8cd87", []},
+  "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "c998673eb009da2ea4dc0e6ef0332534cf679cc4", [ref: "c998673eb009da2ea4dc0e6ef0332534cf679cc4"]},
   "cowlib": {:hex, :cowlib, "2.5.1", "1481324d35b2844767cf988d8e4ce42f0f3b11c29a9e5a430aaa608d4757e3c6", [:rebar3], [], "hexpm"},
   "gun": {:hex, :gun, "1.1.0", "66be4ebb3a8018b2ca0216eb0c5fe89820f3ce3610e9ec0652f525690956f69f", [:rebar3], [{:cowlib, "~> 2.5.1", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
   "protobuf": {:hex, :protobuf, "0.5.3", "7216b9814830a92384c4a99ca1ce35884614517c1cdf0c75ea74ea9bb9fabaeb", [:mix], []},
-  "ranch": {:git, "https://github.com/ninenines/ranch", "cbe24f6fb9833474b22a06fc22cb1a8f168f7fbc", [ref: "1.6.1"]},
+  "ranch": {:git, "https://github.com/ninenines/ranch", "9b8ed47d789412b0021bfc1f94f1c17c387c721c", [ref: "1.6.2"]},
 }

--- a/interop/mix.lock
+++ b/interop/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "c998673eb009da2ea4dc0e6ef0332534cf679cc4", [ref: "c998673eb009da2ea4dc0e6ef0332534cf679cc4"]},
-  "cowlib": {:hex, :cowlib, "2.5.1", "1481324d35b2844767cf988d8e4ce42f0f3b11c29a9e5a430aaa608d4757e3c6", [:rebar3], [], "hexpm"},
-  "gun": {:hex, :gun, "1.1.0", "66be4ebb3a8018b2ca0216eb0c5fe89820f3ce3610e9ec0652f525690956f69f", [:rebar3], [{:cowlib, "~> 2.5.1", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
+  "gun": {:hex, :gun, "1.2.0", "9878541161fb9e0d2fd1b3b38f001ac9c68e3f9075ed647b7827208dc8b3ec2b", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
   "protobuf": {:hex, :protobuf, "0.5.3", "7216b9814830a92384c4a99ca1ce35884614517c1cdf0c75ea74ea9bb9fabaeb", [:mix], []},
-  "ranch": {:git, "https://github.com/ninenines/ranch", "9b8ed47d789412b0021bfc1f94f1c17c387c721c", [ref: "1.6.2"]},
+  "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
 }

--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -157,6 +157,9 @@ defmodule GRPC.Adapter.Cowboy do
     if opts[:cred] do
       opts[:cred].ssl ++
         [
+          # These NPN/ALPN options are hardcoded in :cowboy.start_tls/3 (when calling start/3),
+          # but not in :ranch.child_spec/5 (when calling child_spec/3). We must make sure they
+          # are always provided.
           {:next_protocols_advertised, ["h2", "http/1.1"]},
           {:alpn_preferred_protocols, ["h2", "http/1.1"]}
           | socket_opts

--- a/lib/grpc/adapter/cowboy.ex
+++ b/lib/grpc/adapter/cowboy.ex
@@ -12,14 +12,10 @@ defmodule GRPC.Adapter.Cowboy do
   # Only used in starting a server manually using `GRPC.Server.start(servers)`
   @spec start(GRPC.Server.servers_map(), non_neg_integer, keyword) :: {:ok, pid, non_neg_integer}
   def start(servers, port, opts) do
-    server_args = cowboy_start_args(servers, port, opts)
+    start_args = cowboy_start_args(servers, port, opts)
+    start_func = if opts[:cred], do: :start_tls, else: :start_clear
 
-    {:ok, pid} =
-      if opts[:cred] do
-        apply(:cowboy, :start_tls, server_args)
-      else
-        apply(:cowboy, :start_clear, server_args)
-      end
+    {:ok, pid} = apply(:cowboy, start_func, start_args)
 
     port = :ranch.get_port(servers_name(servers))
     {:ok, pid, port}
@@ -28,14 +24,18 @@ defmodule GRPC.Adapter.Cowboy do
   @spec child_spec(GRPC.Server.servers_map(), non_neg_integer, Keyword.t()) ::
           Supervisor.Spec.spec()
   def child_spec(servers, port, opts) do
-    args = cowboy_start_args(servers, port, opts)
+    [ref, trans_opts, proto_opts] = cowboy_start_args(servers, port, opts)
+    trans_opts = Map.put(trans_opts, :connection_type, :supervisor)
+
+    {transport, protocol} =
+      if opts[:cred] do
+        {:ranch_ssl, :cowboy_tls}
+      else
+        {:ranch_tcp, :cowboy_clear}
+      end
 
     {ref, mfa, type, timeout, kind, modules} =
-      if opts[:cred] do
-        tls_ranch_start_args(args)
-      else
-        clear_ranch_start_args(args)
-      end
+      :ranch.child_spec(ref, transport, trans_opts, protocol, proto_opts)
 
     scheme = if opts[:cred], do: :https, else: :http
     # Wrap real mfa to print starting log
@@ -137,7 +137,10 @@ defmodule GRPC.Adapter.Cowboy do
 
     [
       servers_name(servers),
-      transport_opts(port, opts),
+      %{
+        num_acceptors: @default_num_acceptors,
+        socket_opts: socket_opts(port, opts)
+      },
       %{
         env: %{dispatch: dispatch},
         inactivity_timeout: idle_timeout,
@@ -147,35 +150,20 @@ defmodule GRPC.Adapter.Cowboy do
     ]
   end
 
-  defp transport_opts(port, opts) do
-    list = [port: port, num_acceptors: @default_num_acceptors]
-    list = if opts[:ip], do: [{:ip, opts[:ip]} | list], else: list
+  defp socket_opts(port, opts) do
+    socket_opts = [port: port]
+    socket_opts = if opts[:ip], do: [{:ip, opts[:ip]} | socket_opts], else: socket_opts
 
     if opts[:cred] do
-      opts[:cred].ssl ++ list
+      opts[:cred].ssl ++
+        [
+          {:next_protocols_advertised, ["h2", "http/1.1"]},
+          {:alpn_preferred_protocols, ["h2", "http/1.1"]}
+          | socket_opts
+        ]
     else
-      list
+      socket_opts
     end
-  end
-
-  defp clear_ranch_start_args([ref, trans_opts, proto_opts]) do
-    trans_opts = [connection_type(proto_opts) | trans_opts]
-    :ranch.child_spec(ref, :ranch_tcp, trans_opts, :cowboy_clear, proto_opts)
-  end
-
-  defp tls_ranch_start_args([ref, trans_opts, proto_opts]) do
-    trans_opts = [
-      connection_type(proto_opts),
-      {:next_protocols_advertised, ["h2", "http/1.1"]},
-      {:alpn_preferred_protocols, ["h2", "http/1.1"]}
-      | trans_opts
-    ]
-
-    :ranch.child_spec(ref, :ranch_ssl, trans_opts, :cowboy_tls, proto_opts)
-  end
-
-  defp connection_type(_) do
-    {:connection_type, :supervisor}
   end
 
   defp running_info(scheme, servers, ref) do

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule GRPC.Mixfile do
   defp deps do
     [
       {:protobuf, "~> 0.5"},
-      {:cowboy, github: "ninenines/cowboy"},
+      # FIXME 2018-10-02: We need features of Cowboy only available in the unreleased v2.5.0
+      {:cowboy, github: "ninenines/cowboy", ref: "c998673eb009da2ea4dc0e6ef0332534cf679cc4"},
       {:gun, "~> 1.1"},
       {:cowlib, "~> 2.1", override: true},
       {:ex_doc, "~> 0.14", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -33,10 +33,10 @@ defmodule GRPC.Mixfile do
   defp deps do
     [
       {:protobuf, "~> 0.5"},
-      # FIXME 2018-10-02: We need features of Cowboy only available in the unreleased v2.5.0
-      {:cowboy, github: "ninenines/cowboy", ref: "c998673eb009da2ea4dc0e6ef0332534cf679cc4"},
-      {:gun, "~> 1.1"},
-      {:cowlib, "~> 2.1", override: true},
+      {:cowboy, "~> 2.5"},
+      # FIXME 2018-10-03: gun 1.3.0 currently causes the interop tests to fail:
+      # https://github.com/tony612/grpc-elixir/issues/77
+      {:gun, "~> 1.2.0"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:inch_ex, ">= 0.0.0", only: :docs},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false}

--- a/mix.lock
+++ b/mix.lock
@@ -1,12 +1,12 @@
 %{
-  "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "c998673eb009da2ea4dc0e6ef0332534cf679cc4", [ref: "c998673eb009da2ea4dc0e6ef0332534cf679cc4"]},
-  "cowlib": {:hex, :cowlib, "2.5.1", "1481324d35b2844767cf988d8e4ce42f0f3b11c29a9e5a430aaa608d4757e3c6", [:rebar3], [], "hexpm"},
+  "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "gun": {:hex, :gun, "1.1.0", "66be4ebb3a8018b2ca0216eb0c5fe89820f3ce3610e9ec0652f525690956f69f", [:rebar3], [{:cowlib, "~> 2.5.1", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
+  "gun": {:hex, :gun, "1.2.0", "9878541161fb9e0d2fd1b3b38f001ac9c68e3f9075ed647b7827208dc8b3ec2b", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
   "protobuf": {:hex, :protobuf, "0.5.2", "c1338db827614cbe03a479ac9ef22bd8f3d0ff8a6bb44db5f63037688cd7806c", [:mix], []},
-  "ranch": {:git, "https://github.com/ninenines/ranch", "9b8ed47d789412b0021bfc1f94f1c17c387c721c", [ref: "1.6.2"]},
+  "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "8d634d0ff4ea1ca744a8a789aa5edf6682e8cd87", []},
+  "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "c998673eb009da2ea4dc0e6ef0332534cf679cc4", [ref: "c998673eb009da2ea4dc0e6ef0332534cf679cc4"]},
   "cowlib": {:hex, :cowlib, "2.5.1", "1481324d35b2844767cf988d8e4ce42f0f3b11c29a9e5a430aaa608d4757e3c6", [:rebar3], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
@@ -8,5 +8,5 @@
   "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
   "protobuf": {:hex, :protobuf, "0.5.2", "c1338db827614cbe03a479ac9ef22bd8f3d0ff8a6bb44db5f63037688cd7806c", [:mix], []},
-  "ranch": {:git, "https://github.com/ninenines/ranch", "cbe24f6fb9833474b22a06fc22cb1a8f168f7fbc", [ref: "1.6.1"]},
+  "ranch": {:git, "https://github.com/ninenines/ranch", "9b8ed47d789412b0021bfc1f94f1c17c387c721c", [ref: "1.6.2"]},
 }


### PR DESCRIPTION
This updates grpc to use Ranch 1.6's map-style transport options. Previously a keyword list was used. When using a keyword list and both Ranch options and socket options are specified, Ranch logs deprecation warnings.

This change requires a newer version of Cowboy with a fix for ninenines/cowboy#1324.