### PR TITLE
Travis cleanups & updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ language: elixir
 elixir: '1.6'
 otp_release: '20.3'
 
+script:
+  - mix test
+  - (cd interop && mix deps.get && mix run script/run.exs)
+  # Released inch_ex does not support Elixir 1.7 yet:
+  # https://github.com/rrrene/inch_ex/issues/60
+  - '[[ "$TRAVIS_ELIXIR_VERSION" = 1.7 ]] || mix inch.report'
+
 jobs:
   include:
     - elixir: '1.4'
@@ -11,10 +18,3 @@ jobs:
     - elixir: '1.6'
     - elixir: '1.7'
       otp_release: '21.1'
-
-script:
-  - mix test
-  - (cd interop && mix deps.get && mix run script/run.exs)
-  # Released inch_ex does not support Elixir 1.7 yet:
-  # https://github.com/rrrene/inch_ex/issues/60
-  - '[[ "$TRAVIS_ELIXIR_VERSION" = 1.7 ]] || mix inch.report'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
   - (cd interop && mix deps.get && mix run script/run.exs)
   # Released inch_ex does not support Elixir 1.7 yet:
   # https://github.com/rrrene/inch_ex/issues/60
-  - '[[ "$TRAVIS_ELIXIR_VERSION" = 1.7.* ]] || mix inch.report'
+  - '[[ "$TRAVIS_ELIXIR_VERSION" = 1.7 ]] || mix inch.report'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
   - (cd interop && mix deps.get && mix run script/run.exs)
   # Released inch_ex does not support Elixir 1.7 yet:
   # https://github.com/rrrene/inch_ex/issues/60
-  - [[ "$TRAVIS_ELIXIR_VERSION" = 1.7.* ]] || mix inch.report
+  - '[[ "$TRAVIS_ELIXIR_VERSION" = 1.7.* ]] || mix inch.report'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ script:
   # Released inch_ex does not support Elixir 1.7 yet:
   # https://github.com/rrrene/inch_ex/issues/60
   - '[[ "$TRAVIS_ELIXIR_VERSION" = 1.7 ]] || mix inch.report'
+  # mix format not available on Elixir 1.4/1.5
+  - '[[ "$TRAVIS_ELIXIR_VERSION" =~ 1.[4-5] ]] || mix format --check-formatted'
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: elixir
-elixir:
-  - 1.4.5
-  - 1.5.3
-  - 1.6.1
-otp_release:
-  - 19.3
-  - 20.2
+
+# Default Elixir and OTP versions
+elixir: '1.6'
+otp_release: '20.3'
+
+jobs:
+  include:
+    - elixir: '1.4'
+    - elixir: '1.5'
+    - elixir: '1.6'
+    - elixir: '1.7'
+      otp_release: '21.1'
+
 script:
   - mix test
   - cd interop && mix deps.get && mix run script/run.exs

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jobs:
 
 script:
   - mix test
-  - cd interop && mix deps.get && mix run script/run.exs
-after_script:
-  - mix deps.get --only docs
-  - MIX_ENV=docs mix inch.report
+  - (cd interop && mix deps.get && mix run script/run.exs)
+  # Released inch_ex does not support Elixir 1.7 yet:
+  # https://github.com/rrrene/inch_ex/issues/60
+  - [[ "$TRAVIS_ELIXIR_VERSION" = 1.7.* ]] || mix inch.report

--- a/lib/grpc/error.ex
+++ b/lib/grpc/error.ex
@@ -17,11 +17,12 @@ defmodule GRPC.RPCError do
 
   @spec exception(Status.t(), String.t()) :: t
   def new(status) when is_atom(status) do
-    exception([status: status])
+    exception(status: status)
   end
 
   def exception(args) when is_list(args) do
     error = parse_args(args, %__MODULE__{})
+
     if error.message do
       error
     else
@@ -30,15 +31,18 @@ defmodule GRPC.RPCError do
   end
 
   defp parse_args([], acc), do: acc
-  defp parse_args([{:status, status}|t], acc) when is_integer(status) do
+
+  defp parse_args([{:status, status} | t], acc) when is_integer(status) do
     acc = %{acc | status: status}
     parse_args(t, acc)
   end
-  defp parse_args([{:status, status}|t], acc) when is_atom(status) do
+
+  defp parse_args([{:status, status} | t], acc) when is_atom(status) do
     acc = %{acc | status: apply(GRPC.Status, status, [])}
     parse_args(t, acc)
   end
-  defp parse_args([{:message, message}|t], acc) when is_binary(message) do
+
+  defp parse_args([{:message, message} | t], acc) when is_binary(message) do
     acc = %{acc | message: message}
     parse_args(t, acc)
   end
@@ -47,20 +51,34 @@ defmodule GRPC.RPCError do
     %GRPC.RPCError{status: status, message: message}
   end
 
-  defp status_message(1),  do: "The operation was cancelled (typically by the caller)"
-  defp status_message(2),  do: "Unknown error"
-  defp status_message(3),  do: "Client specified an invalid argument"
-  defp status_message(4),  do: "Deadline expired before operation could complete"
-  defp status_message(5),  do: "Some requested entity (e.g., file or directory) was not found"
-  defp status_message(6),  do: "Some entity that we attempted to create (e.g., file or directory) already exists"
-  defp status_message(7),  do: "The caller does not have permission to execute the specified operation"
-  defp status_message(8),  do: "Some resource has been exhausted"
-  defp status_message(9),  do: "Operation was rejected because the system is not in a state required for the operation's execution"
+  defp status_message(1), do: "The operation was cancelled (typically by the caller)"
+  defp status_message(2), do: "Unknown error"
+  defp status_message(3), do: "Client specified an invalid argument"
+  defp status_message(4), do: "Deadline expired before operation could complete"
+  defp status_message(5), do: "Some requested entity (e.g., file or directory) was not found"
+
+  defp status_message(6),
+    do: "Some entity that we attempted to create (e.g., file or directory) already exists"
+
+  defp status_message(7),
+    do: "The caller does not have permission to execute the specified operation"
+
+  defp status_message(8), do: "Some resource has been exhausted"
+
+  defp status_message(9),
+    do:
+      "Operation was rejected because the system is not in a state required for the operation's execution"
+
   defp status_message(10), do: "The operation was aborted"
   defp status_message(11), do: "Operation was attempted past the valid range"
-  defp status_message(12), do: "Operation is not implemented or not supported/enabled in this service"
+
+  defp status_message(12),
+    do: "Operation is not implemented or not supported/enabled in this service"
+
   defp status_message(13), do: "Internal errors"
   defp status_message(14), do: "The service is currently unavailable"
   defp status_message(15), do: "Unrecoverable data loss or corruption"
-  defp status_message(16), do: "The request does not have valid authentication credentials for the operation"
+
+  defp status_message(16),
+    do: "The request does not have valid authentication credentials for the operation"
 end

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule GRPC.Mixfile do
       {:gun, "~> 1.1"},
       {:cowlib, "~> 2.1", override: true},
       {:ex_doc, "~> 0.14", only: :dev},
-      {:inch_ex, ">= 0.0.0", only: :docs},
+      {:inch_ex, "~> 1.0", only: [:dev, :test]},
       {:dialyxir, "~> 0.5", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,8 +5,8 @@
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "gun": {:hex, :gun, "1.1.0", "66be4ebb3a8018b2ca0216eb0c5fe89820f3ce3610e9ec0652f525690956f69f", [:rebar3], [{:cowlib, "~> 2.5.1", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm"},
-  "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
-  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "inch_ex": {:hex, :inch_ex, "1.0.1", "1f0af1a83cec8e56f6fc91738a09c838e858db3d78ef5f2ec040fe4d5a62dabf", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "protobuf": {:hex, :protobuf, "0.5.2", "c1338db827614cbe03a479ac9ef22bd8f3d0ff8a6bb44db5f63037688cd7806c", [:mix], []},
   "ranch": {:git, "https://github.com/ninenines/ranch", "cbe24f6fb9833474b22a06fc22cb1a8f168f7fbc", [ref: "1.6.1"]},
 }

--- a/test/grpc/integration/server_test.exs
+++ b/test/grpc/integration/server_test.exs
@@ -138,10 +138,11 @@ defmodule GRPC.Integration.ServerTest do
       {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
       rect = Routeguide.Rectangle.new()
       error = %GRPC.RPCError{message: "Deadline expired", status: 4}
-      assert {:error, ^error} = channel |> Routeguide.RouteGuide.Stub.list_features(rect, timeout: 500)
+
+      assert {:error, ^error} =
+               channel |> Routeguide.RouteGuide.Stub.list_features(rect, timeout: 500)
     end)
   end
-
 
   test "return normally for a little slow server" do
     run_server([SlowServer], fn port ->


### PR DESCRIPTION
Various fixes and improvements:
* Run latest of each of 1.4, 1.5, 1.6 Elixir releases
* Only run tests on OTP 20+
* Add Elixir 1.7/OTP 21 build
* Move `inch_ex` to dev/test environment and make it actually work, update `inch_ex` to 1.0, run in subshell so that we don't stay in the `interop` directory
* Run `mix format` and add a build step to check that files are formatted

Further improvements that could be done if there is interest, but probably best for other PRs:
* Run dialyxir (grpc doesn't currently pass dialyzer without errors)
* Code coverage
* Credo?