### PR TITLE
Added disconnect

### DIFF
--- a/lib/grpc/adapter/gun.ex
+++ b/lib/grpc/adapter/gun.ex
@@ -48,6 +48,10 @@ defmodule GRPC.Adapter.Gun do
     {:ok, %{channel | adapter_payload: %{conn_pid: nil}}}
   end
 
+  def disconnect(%{adapter_payload: %{conn_pid: nil}} = channel) do
+    {:ok, channel}
+  end
+
   defp open({:local, socket_path}, _port, open_opts),
     do: :gun.open_unix(socket_path, open_opts)
 

--- a/lib/grpc/adapter/gun.ex
+++ b/lib/grpc/adapter/gun.ex
@@ -42,6 +42,12 @@ defmodule GRPC.Adapter.Gun do
     end
   end
 
+  def disconnect(%{adapter_payload: %{conn_pid: gun_pid}} = channel)
+      when is_pid(gun_pid) do
+    :ok = :gun.close(gun_pid)
+    {:ok, %{channel | adapter_payload: %{conn_pid: nil}}}
+  end
+
   defp open({:local, socket_path}, _port, open_opts),
     do: :gun.open_unix(socket_path, open_opts)
 

--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -130,6 +130,14 @@ defmodule GRPC.Stub do
   end
 
   @doc """
+  Disconnects the adapter and frees any resources the adapter is consuming
+  """
+  @spec disconnect(Channel.t()) :: {:ok, Channel.t()} | {:error, any}
+  def disconnect(%Channel{adapter: adapter} = channel) do
+    adapter.disconnect(channel)
+  end
+
+  @doc """
   The actual function invoked when invoking a rpc function.
 
   ## Returns

--- a/test/grpc/integration/stub_test.exs
+++ b/test/grpc/integration/stub_test.exs
@@ -38,12 +38,12 @@ defmodule GRPC.Integration.StubTest do
 
       gun_port = port_for(gun_conn_pid)
       # Using :erlang.monitor to be compatible with <= 1.5
-      :erlang.monitor(:port, gun_port)
+      ref = :erlang.monitor(:port, gun_port)
 
       {:ok, channel} = GRPC.Stub.disconnect(channel)
 
       assert %{adapter_payload: %{conn_pid: nil}} = channel
-      assert_receive {:DOWN, _, :port, ^gun_port, _}
+      assert_receive {:DOWN, ^ref, :port, ^gun_port, _}
       assert port_for(gun_conn_pid) == nil
     end)
   end
@@ -52,7 +52,7 @@ defmodule GRPC.Integration.StubTest do
     run_server(HelloServer, fn port ->
       {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
       {:ok, channel} = GRPC.Stub.disconnect(channel)
-      {:ok, channel} = GRPC.Stub.disconnect(channel)
+      {:ok, _channel} = GRPC.Stub.disconnect(channel)
     end)
   end
 

--- a/test/grpc/integration/stub_test.exs
+++ b/test/grpc/integration/stub_test.exs
@@ -37,7 +37,8 @@ defmodule GRPC.Integration.StubTest do
       %{adapter_payload: %{conn_pid: gun_conn_pid}} = channel
 
       gun_port = port_for(gun_conn_pid)
-      Port.monitor(gun_port)
+      # Using :erlang.monitor to be compatible with <= 1.5
+      :erlang.monitor(:port, gun_port)
 
       {:ok, channel} = GRPC.Stub.disconnect(channel)
 

--- a/test/grpc/integration/stub_test.exs
+++ b/test/grpc/integration/stub_test.exs
@@ -32,7 +32,6 @@ defmodule GRPC.Integration.StubTest do
 
   test "you can disconnect stubs" do
     run_server(HelloServer, fn port ->
-      port_count_before = :erlang.ports() |> Enum.count()
       {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
 
       %{adapter_payload: %{conn_pid: gun_conn_pid}} = channel
@@ -45,6 +44,14 @@ defmodule GRPC.Integration.StubTest do
       assert %{adapter_payload: %{conn_pid: nil}} = channel
       assert_receive {:DOWN, _, :port, ^gun_port, _}
       assert port_for(gun_conn_pid) == nil
+    end)
+  end
+
+  test "disconnecting a disconnected channel is a no-op" do
+    run_server(HelloServer, fn port ->
+      {:ok, channel} = GRPC.Stub.connect("localhost:#{port}")
+      {:ok, channel} = GRPC.Stub.disconnect(channel)
+      {:ok, channel} = GRPC.Stub.disconnect(channel)
     end)
   end
 


### PR DESCRIPTION
From what I could tell, there was no way to disconnect a gun client,
which was causing us to leak ports. This PR adds the ability to
disconnect ourselves and clean up any open ports.